### PR TITLE
handle null in torrent_data.json fix 

### DIFF
--- a/libgen_seedtools/routines.py
+++ b/libgen_seedtools/routines.py
@@ -85,7 +85,7 @@ def fetchall(ctx: Ctx, update_list=False, dry_run=False, auto_verify=False) -> N
     seeders_arr = [x.seeders for x in filedata]
     seeders_mean = statistics.mean(seeders_arr)
     seeders_median = statistics.median(seeders_arr)
-    dht_peers_arr = [x.dht_peers for x in filedata]
+    dht_peers_arr = [x.dht_peers if x.dht_peers else 0 for x in filedata]
     dht_peers_mean = statistics.mean(dht_peers_arr)
     dht_peers_median = statistics.median(dht_peers_arr)
     size_arr = [x.size_bytes for x in filedata]

--- a/libgen_seedtools/schemas.py
+++ b/libgen_seedtools/schemas.py
@@ -11,8 +11,8 @@ class TorrentFileData(BaseModel):
     infohash: str
     created_unix: int
     scraped_date: int
-    dht_scraped: int
-    dht_peers: int
+    dht_scraped: Union[int, None]
+    dht_peers: Union[int, None]
     seeders: int
     leechers: int
     size_bytes: int


### PR DESCRIPTION
Fixes #11 by handling null in `torrent_data.json` that resulted in the following stacktrace

```
Loading torrent data.
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/libgen-seedtools", line 8, in <module>
    sys.exit(cli())
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/libgen_seedtools/cli.py", line 61, in fetch
    fetchall(ctx, update_list, dry_run, auto_verify)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/libgen_seedtools/routines.py", line 81, in fetchall
    load_torrent_data(ctx, jsonfilepath, force=update_list),
  File "/home/ubuntu/.local/lib/python3.10/site-packages/libgen_seedtools/routines.py", line 69, in load_torrent_data
    data.append(TorrentFileData(**d))
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 2 validation errors for TorrentFileData
dht_scraped
  none is not an allowed value (type=type_error.none.not_allowed)
dht_peers
  none is not an allowed value (type=type_error.none.not_allowed)
```

@subdavis  LGTY?